### PR TITLE
This allows us to be able to dictate the order the JS files will be loaded

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,8 @@
 // about supported directives.
 //
 //= require turbolinks
+//= require map.js
 //= require react
 //= require react_ujs
 //= require components
-//= require_tree .
+


### PR DESCRIPTION


By removing `/=require tree`